### PR TITLE
Fix invalid file descriptor initialization and replace deprecated sleep function

### DIFF
--- a/gpu.c
+++ b/gpu.c
@@ -17,7 +17,7 @@
 #include "vgafon.h"
 
 extern struct bitmap_font vgafon;
-int vt_fd = NULL;
+int vt_fd = -1;  // Use -1 instead of NULL for invalid file descriptor
 // Text message system
 text_message_t text_messages[MAX_TEXT_MESSAGES] = {0};
 

--- a/main.c
+++ b/main.c
@@ -3,6 +3,7 @@
 #include <pthread.h>
 #include <unistd.h>
 #include "key.h"
+#include <time.h>
 #include "gpu.h"
 #include "mouse.h"
 #include "wm.h"
@@ -39,7 +40,11 @@ int main() {
     sleep(2);
     system("bash -c clear > /dev/tty2");
     // boot system
-    usleep(100000); // 100ms pause to let draw() start
+    struct timespec req = {0};
+    req.tv_sec = 0;            // seconds
+    req.tv_nsec = 100000000L;  // nanoseconds (100,000,000 ns = 100 ms)
+
+    nanosleep(&req, NULL); // 100ms pause to let draw() start
     add_text_message("Welcome to NovaOS!", 10, 10, 255, 255, 255);
     // sleep(2);
     add_text_message("Initialised Framebuffer (gpu.c)", 10, 30, 255, 255, 255);

--- a/wm.h
+++ b/wm.h
@@ -19,6 +19,7 @@ extern size_t window_count;
 // Function declarations
 void wm_init(int bufptr[800][1280][3]);
 void wm_draw(volatile int *running);
+void destroy_windows(Window *windows, size_t count);
 
 #endif // WM_H
 


### PR DESCRIPTION
Corrects the initialization of the file descriptor to use -1 instead of NULL and replaces the deprecated `usleep` function with `nanosleep` to address code scanning alert #4.